### PR TITLE
Don't use make in the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM golang:1.19-alpine3.16 AS builder
 ARG VERSION
+ARG DATABASE
+ARG SOURCE
 
 RUN apk add --no-cache git gcc musl-dev make
 
@@ -13,7 +15,7 @@ RUN go mod download
 
 COPY . ./
 
-RUN make build-docker
+RUN CGO_ENABLED=0 go build -a -o build/migrate.linux-386 -ldflags="-s -w -X main.Version=${VERSION}" -tags "$(DATABASE) $(SOURCE)" ./cmd/migrate
 
 FROM alpine:3.16
 

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ build-cli: clean
 	cat ./cli/build/sha256sum.txt
 
 build:
-	docker build --build-arg VERSION=$(VERSION) . -t infoblox/migrate -t infoblox/migrate:$(VERSION)
+	docker build --build-arg VERSION=$(VERSION) --build-arg DATABASE="$(DATABASE)" --build-arg SOURCE="$(SOURCE)" . -t infoblox/migrate -t infoblox/migrate:$(VERSION)
 
 docker-push:
 	docker push infoblox/migrate:$(VERSION)


### PR DESCRIPTION
Using `make` in Docker is causing a problem in our Jenkins build process