### PR TITLE
Fix the password parsing issue

### DIFF
--- a/internal/cli/main.go
+++ b/internal/cli/main.go
@@ -77,7 +77,7 @@ func EscapeIfNeeded(str string) string {
 		// If the str is already unescaped or an error occurred, escape it
 		return url.QueryEscape(str)
 	}
-	// If the str was successfully unescaped, return it as is
+	// If the str was successfully unescaped and is different from the original, return the original
 	return str
 }
 

--- a/internal/cli/main.go
+++ b/internal/cli/main.go
@@ -67,8 +67,18 @@ func printUsageAndExit() {
 
 func dbMakeConnectionString(driver, user, password, address, name, ssl string) string {
 	return fmt.Sprintf("%s://%s:%s@%s/%s?sslmode=%s",
-		driver, url.QueryEscape(user), url.QueryEscape(password), address, name, ssl,
+		driver, EscapeIfNeeded(user), EscapeIfNeeded(password), address, name, ssl,
 	)
+}
+
+func EscapeIfNeeded(str string) string {
+	unescapedStr, err := url.QueryUnescape(str)
+	if err != nil || unescapedStr == str {
+		// If the str is already unescaped or an error occurred, escape it
+		return url.QueryEscape(str)
+	}
+	// If the str was successfully unescaped, return it as is
+	return str
 }
 
 // Main function of a cli application. It is public for backwards compatibility with `cli` package

--- a/internal/cli/main_test.go
+++ b/internal/cli/main_test.go
@@ -1,0 +1,48 @@
+package cli
+
+import (
+	"testing"
+)
+
+func TestEscapeIfNeeded(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "AlreadyEscaped",
+			input:    "hello%20world",
+			expected: "hello%20world",
+		},
+		{
+			name:     "Unescaped",
+			input:    "hello world",
+			expected: "hello+world",
+		},
+		{
+			name:     "PartiallyEscaped",
+			input:    "hello%20world!",
+			expected: "hello%20world!",
+		},
+		{
+			name:     "EmptyString",
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "SpecialCharacters",
+			input:    "hello@world.com",
+			expected: "hello%40world.com",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := EscapeIfNeeded(tt.input)
+			if result != tt.expected {
+				t.Errorf("EscapeIfNeeded(%q) actual = %q; want = %q", tt.input, result, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Escaping an already escaped password is causing the migrate container to error out with the following error.

```
 k -n discovery-service logs ds-td-snow-mig-up-8088-38-80-113830-wgqrq
Defaulted container "migration" out of: migration, migration-source (init), migration-check (init)
{"level":"info","msg":"error: pq: password authentication failed for user \"discovery_service_user\"","time":"2024-10-08T11:46:45Z"}
```

Added the fix to Queryescape user and password only if it is not already escaped. 