### PR TITLE
Migrate AWS S3 source driver from aws-sdk-go v1 to v2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/ClickHouse/clickhouse-go v1.4.3
 	github.com/DATA-DOG/go-sqlmock v1.5.0 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
-	github.com/aws/aws-sdk-go v1.49.6
 	github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.11.33 // indirect
 	github.com/cenkalti/backoff/v4 v4.1.2
 	github.com/cockroachdb/cockroach-go/v2 v2.1.1
@@ -99,7 +98,7 @@ require (
 	github.com/andybalholm/brotli v1.0.4 // indirect
 	github.com/apache/arrow/go/v10 v10.0.1 // indirect
 	github.com/apache/thrift v0.16.0 // indirect
-	github.com/aws/aws-sdk-go-v2 v1.16.16 // indirect
+	github.com/aws/aws-sdk-go-v2 v1.16.16
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.4.8 // indirect
 	github.com/aws/aws-sdk-go-v2/credentials v1.12.20 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.23 // indirect
@@ -109,7 +108,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.1.18 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.9.17 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.13.17 // indirect
-	github.com/aws/aws-sdk-go-v2/service/s3 v1.27.11 // indirect
+	github.com/aws/aws-sdk-go-v2/service/s3 v1.27.11
 	github.com/aws/smithy-go v1.13.3 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/cloudflare/golz4 v0.0.0-20150217214814-ef862a3cdc58 // indirect
@@ -199,12 +198,18 @@ require (
 )
 
 require (
+	github.com/aws/aws-sdk-go-v2/config v1.17.7
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/spf13/pflag v1.0.10
 	github.com/spf13/viper v1.21.0
 )
 
 require (
+	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.12.17 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/ini v1.3.24 // indirect
+	github.com/aws/aws-sdk-go-v2/service/sso v1.11.23 // indirect
+	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.13.5 // indirect
+	github.com/aws/aws-sdk-go-v2/service/sts v1.16.19 // indirect
 	github.com/go-viper/mapstructure/v2 v2.4.0 // indirect
 	github.com/goccy/go-json v0.9.11 // indirect
 	github.com/godbus/dbus v0.0.0-20190726142602-4481cbc300e2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -684,8 +684,6 @@ github.com/apache/arrow/go/v10 v10.0.1/go.mod h1:YvhnlEePVnBS4+0z3fhPfUy7W1Ikj0I
 github.com/apache/arrow/go/v11 v11.0.0/go.mod h1:Eg5OsL5H+e299f7u5ssuXsuHQVEGC4xei5aX110hRiI=
 github.com/apache/thrift v0.16.0 h1:qEy6UW60iVOlUy+b9ZR0d5WzUWYGOo4HfopoyBaNmoY=
 github.com/apache/thrift v0.16.0/go.mod h1:PHK3hniurgQaNMZYaCLEqXKsYK8upmhPbmdP2FXSqgU=
-github.com/aws/aws-sdk-go v1.49.6 h1:yNldzF5kzLBRvKlKz1S0bkvc2+04R1kt13KfBWQBfFA=
-github.com/aws/aws-sdk-go v1.49.6/go.mod h1:LF8svs817+Nz+DmiMQKTO3ubZ/6IaTpq3TjupRn3Eqk=
 github.com/aws/aws-sdk-go-v2 v1.16.16 h1:M1fj4FE2lB4NzRb9Y0xdWsn2P0+2UHVxwKyOa4YJNjk=
 github.com/aws/aws-sdk-go-v2 v1.16.16/go.mod h1:SwiyXi/1zTUZ6KIAmLK5V5ll8SiURNUYOqTerZPaF9k=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.4.8 h1:tcFliCWne+zOuUfKNRn8JdFBuWPDuISDH08wD2ULkhk=

--- a/source/aws_s3/s3.go
+++ b/source/aws_s3/s3.go
@@ -1,6 +1,7 @@
 package awss3
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"net/url"
@@ -8,10 +9,9 @@ import (
 	"path"
 	"strings"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/session"
-	"github.com/aws/aws-sdk-go/service/s3"
-	"github.com/aws/aws-sdk-go/service/s3/s3iface"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/golang-migrate/migrate/v4/source"
 )
 
@@ -19,8 +19,14 @@ func init() {
 	source.Register("s3", &s3Driver{})
 }
 
+// S3API defines the subset of the S3 client API used by this driver.
+type S3API interface {
+	ListObjectsV2(ctx context.Context, params *s3.ListObjectsV2Input, optFns ...func(*s3.Options)) (*s3.ListObjectsV2Output, error)
+	GetObject(ctx context.Context, params *s3.GetObjectInput, optFns ...func(*s3.Options)) (*s3.GetObjectOutput, error)
+}
+
 type s3Driver struct {
-	s3client   s3iface.S3API
+	s3client   S3API
 	config     *Config
 	migrations *source.Migrations
 }
@@ -31,22 +37,22 @@ type Config struct {
 }
 
 func (s *s3Driver) Open(folder string) (source.Driver, error) {
-	config, err := parseURI(folder)
+	cfg, err := parseURI(folder)
 	if err != nil {
 		return nil, err
 	}
 
-	sess, err := session.NewSession()
+	awsCfg, err := config.LoadDefaultConfig(context.Background())
 	if err != nil {
 		return nil, err
 	}
 
-	return WithInstance(s3.New(sess), config)
+	return WithInstance(s3.NewFromConfig(awsCfg), cfg)
 }
 
-func WithInstance(s3client s3iface.S3API, config *Config) (source.Driver, error) {
+func WithInstance(s3client S3API, cfg *Config) (source.Driver, error) {
 	driver := &s3Driver{
-		config:     config,
+		config:     cfg,
 		s3client:   s3client,
 		migrations: source.NewMigrations(),
 	}
@@ -76,7 +82,7 @@ func parseURI(uri string) (*Config, error) {
 }
 
 func (s *s3Driver) loadMigrations() error {
-	output, err := s.s3client.ListObjects(&s3.ListObjectsInput{
+	output, err := s.s3client.ListObjectsV2(context.Background(), &s3.ListObjectsV2Input{
 		Bucket:    aws.String(s.config.Bucket),
 		Prefix:    aws.String(s.config.Prefix),
 		Delimiter: aws.String("/"),
@@ -85,13 +91,13 @@ func (s *s3Driver) loadMigrations() error {
 		return err
 	}
 	for _, object := range output.Contents {
-		_, fileName := path.Split(aws.StringValue(object.Key))
+		_, fileName := path.Split(aws.ToString(object.Key))
 		m, err := source.DefaultParse(fileName)
 		if err != nil {
 			continue
 		}
 		if !s.migrations.Append(m) {
-			return fmt.Errorf("unable to parse file %v", aws.StringValue(object.Key))
+			return fmt.Errorf("unable to parse file %v", aws.ToString(object.Key))
 		}
 	}
 	return nil
@@ -141,7 +147,7 @@ func (s *s3Driver) ReadDown(version uint) (io.ReadCloser, string, error) {
 
 func (s *s3Driver) open(m *source.Migration) (io.ReadCloser, string, error) {
 	key := path.Join(s.config.Prefix, m.Raw)
-	object, err := s.s3client.GetObject(&s3.GetObjectInput{
+	object, err := s.s3client.GetObject(context.Background(), &s3.GetObjectInput{
 		Bucket: aws.String(s.config.Bucket),
 		Key:    aws.String(key),
 	})

--- a/source/aws_s3/s3_test.go
+++ b/source/aws_s3/s3_test.go
@@ -1,13 +1,15 @@
 package awss3
 
 import (
+	"context"
 	"errors"
 	"io"
 	"strings"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/s3/types"
 	st "github.com/golang-migrate/migrate/v4/source/testing"
 	"github.com/stretchr/testify/assert"
 )
@@ -89,23 +91,22 @@ func TestParseURI(t *testing.T) {
 }
 
 type fakeS3 struct {
-	s3.S3
 	bucket  string
 	objects map[string]string
 }
 
-func (s *fakeS3) ListObjects(input *s3.ListObjectsInput) (*s3.ListObjectsOutput, error) {
-	bucket := aws.StringValue(input.Bucket)
+func (s *fakeS3) ListObjectsV2(_ context.Context, input *s3.ListObjectsV2Input, _ ...func(*s3.Options)) (*s3.ListObjectsV2Output, error) {
+	bucket := aws.ToString(input.Bucket)
 	if bucket != s.bucket {
 		return nil, errors.New("bucket not found")
 	}
-	prefix := aws.StringValue(input.Prefix)
-	delimiter := aws.StringValue(input.Delimiter)
-	var output s3.ListObjectsOutput
+	prefix := aws.ToString(input.Prefix)
+	delimiter := aws.ToString(input.Delimiter)
+	var output s3.ListObjectsV2Output
 	for name := range s.objects {
 		if strings.HasPrefix(name, prefix) {
 			if delimiter == "" || !strings.Contains(strings.Replace(name, prefix, "", 1), delimiter) {
-				output.Contents = append(output.Contents, &s3.Object{
+				output.Contents = append(output.Contents, types.Object{
 					Key: aws.String(name),
 				})
 			}
@@ -114,12 +115,12 @@ func (s *fakeS3) ListObjects(input *s3.ListObjectsInput) (*s3.ListObjectsOutput,
 	return &output, nil
 }
 
-func (s *fakeS3) GetObject(input *s3.GetObjectInput) (*s3.GetObjectOutput, error) {
-	bucket := aws.StringValue(input.Bucket)
+func (s *fakeS3) GetObject(_ context.Context, input *s3.GetObjectInput, _ ...func(*s3.Options)) (*s3.GetObjectOutput, error) {
+	bucket := aws.ToString(input.Bucket)
 	if bucket != s.bucket {
 		return nil, errors.New("bucket not found")
 	}
-	if data, ok := s.objects[aws.StringValue(input.Key)]; ok {
+	if data, ok := s.objects[aws.ToString(input.Key)]; ok {
 		body := io.NopCloser(strings.NewReader(data))
 		return &s3.GetObjectOutput{Body: body}, nil
 	}


### PR DESCRIPTION
## Summary
- Migrate `source/aws_s3` from AWS SDK for Go v1 (`aws-sdk-go`) to v2 (`aws-sdk-go-v2`)
- Replace `session.NewSession()` with `config.LoadDefaultConfig()` and `s3.NewFromConfig()`
- Use `ListObjectsV2` instead of `ListObjects`
- Define local `S3API` interface replacing `s3iface.S3API`
- Preserve existing public API (`Config`, `WithInstance`, `parseURI`)

Supersedes #53 with minimal changes focused solely on the SDK v2 migration.

Based on work by @bkulkarni2.

## Test plan
- [x] `go test ./source/aws_s3/...` passes
- [x] `go build ./...` succeeds

Co-Authored-By: Bhargav Kulkarni <bkulkarni2@users.noreply.github.com>